### PR TITLE
feat: support Railway MySQL env variables

### DIFF
--- a/docker-config.inc.php
+++ b/docker-config.inc.php
@@ -64,6 +64,34 @@ $db_password = $_ENV['MRBS_DB_PASSWORD'] ?? 'mrbs-password';
 // Prefix for table names.  This will allow multiple installations where only
 // one database is available
 $db_tbl_prefix = $_ENV['MRBS_DB_TBL_PREFIX'] ?? 'mrbs_';
+
+// Allow configuration via common Railway environment variables
+$db_host = $_ENV['MYSQLHOST'] ?? $_ENV['MYSQL_HOST'] ?? $db_host;
+if (!empty($_ENV['MYSQLPORT'])) {
+  $db_port = $_ENV['MYSQLPORT'];
+}
+$db_database = $_ENV['MYSQLDATABASE'] ?? $_ENV['MYSQL_DATABASE'] ?? $db_database;
+$db_login = $_ENV['MYSQLUSER'] ?? $db_login;
+$db_password = $_ENV['MYSQLPASSWORD'] ?? $_ENV['MYSQL_ROOT_PASSWORD'] ?? $db_password;
+
+if ($url = $_ENV['MYSQL_URL'] ?? $_ENV['MYSQL_PUBLIC_URL'] ?? null) {
+  $url_parts = parse_url($url);
+  if (!empty($url_parts['host'])) {
+    $db_host = $url_parts['host'];
+  }
+  if (!empty($url_parts['port'])) {
+    $db_port = $url_parts['port'];
+  }
+  if (!empty($url_parts['user'])) {
+    $db_login = $url_parts['user'];
+  }
+  if (!empty($url_parts['pass'])) {
+    $db_password = $url_parts['pass'];
+  }
+  if (!empty($url_parts['path'])) {
+    $db_database = ltrim($url_parts['path'], '/');
+  }
+}
 // Set $db_persist to TRUE to use PHP persistent (pooled) database connections.  Note
 // that persistent connections are not recommended unless your system suffers significant
 // performance problems without them.   They can cause problems with transactions and


### PR DESCRIPTION
## Summary
- allow `docker-config.inc.php` to read Railway's MySQL environment variables

## Testing
- `php -l docker-config.inc.php`


------
https://chatgpt.com/codex/tasks/task_e_68af68a262f8832d9c6f6457aad7533b