### PR TITLE
fix: update ICU package for Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.2-apache
 
 RUN a2enmod rewrite
-RUN apt-get update && apt-get install -y libicu72 libicu-dev locales-all
+RUN apt-get update && apt-get install -y libicu-dev locales-all
 RUN docker-php-ext-install mysqli pdo pdo_mysql intl
 
 COPY web/ /var/www/html/


### PR DESCRIPTION
## Summary
- remove specific libicu72 package and use libicu-dev

## Testing
- ⚠️ `docker build -t test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e84ab04832dbe671dffeee2ac69